### PR TITLE
fix typo in README.md apt-get instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ executable and run it. On Ubuntu 22.04 or other very recent Linux
 distros, you need to install libfuse2:
 
 ```text
-sudo apt-get libfuse2
+sudo apt-get install libfuse2
 ```
 
 This annoyance will hopefully be fixed in the future. The AppImage devs


### PR DESCRIPTION
was missing the word "install" !