### PR TITLE
Add missing executable bits

### DIFF
--- a/src/libs/decoders/internal/Makefile
+++ b/src/libs/decoders/internal/Makefile
@@ -109,6 +109,7 @@ speexdsp/configure: speexdsp/autogen.sh
 speexdsp/Makefile: speexdsp/configure
 	cd speexdsp \
 	&& sed -i.bak 's/.*PKG_CHECK_MODULES.*//g' configure \
+	&& chmod a+x configure \
 	&& ./configure --disable-shared --disable-examples --with-fft=smallft
 
 lib/libspeexdsp.a: speexdsp/Makefile


### PR DESCRIPTION
In my setup `sed -i` moves the original file aside and creates a new file that misses the executable bits. That PR fixes it.